### PR TITLE
[DR-3348] Remove elasticsearch from umbrella chart release

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -10,7 +10,7 @@ inputs:
     default: "datarepo"
   helm_charts:
     description: "list of helm charts you release in umbrella"
-    default: "create-secret-manager-secret,gcloud-sqlproxy,datarepo-api,datarepo-ui,oidc-proxy,de-elasticsearch"
+    default: "create-secret-manager-secret,gcloud-sqlproxy,datarepo-api,datarepo-ui,oidc-proxy"
 runs:
   using: "docker"
   image: "./Dockerfile"


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/DR-3348

[This PR](https://github.com/broadinstitute/datarepo-helm/pull/247) removed the `de-elasticsearch` chart from the datarepo umbrella chart, so it also needs to be removed from this action